### PR TITLE
feat: add Algolia search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,7 +84,12 @@ module.exports = {
       ],
       copyright: ``,
     },
-    image: 'img/splash.png'
+    image: 'img/splash.png',
+    algolia: {
+      apiKey: '21171da7394be9a61a0174dd81b75b70',
+      indexName: 'nodecg',
+      algoliaOptions: {}
+    }
   },
   presets: [
     [


### PR DESCRIPTION
Right now it's broken because it's pointing at nodecg.com, which is of course still the old site. Once the new site is deployed, the search will fix itself within 24 hours.

Closes #14