### PR TITLE
Fix key name of property in Assets README

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -42,7 +42,7 @@ These Replicants are arrays. Each item in these arrays describes one of the uplo
 ```json
 {
   "base": "square.png",
-  "bundleName": "test-bundle",
+  "namespace": "test-bundle",
   "category": "thumbnails",
   "ext": ".png",
   "name": "square",


### PR DESCRIPTION
It's been incorrect for a while so thought I'd fix it now I remembered it. Not sure why the actual name is `namespace` and not `bundleName` but that's for another time.