### PR TITLE
fix: update commands for git clone installation method

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -22,10 +22,14 @@ nodecg setup
 Cloning from GitHub:
 
 ```bash
-git clone https://github.com/nodecg/nodecg.git
+git clone --branch legacy-1.x https://github.com/nodecg/nodecg.git
 cd nodecg
 npm install --production
 ```
+
+:::caution
+Ensure to specify a branch when cloning, as the master branch is in an unstable state while v2.0 is being developed.
+:::
 
 ## Start
 


### PR DESCRIPTION
Right now following the instructions to the quick start installation guide's cloning method causes the user to setup the master branch, which is not suitable for production at this time.

Added a branch flag to the suggested clone command and added a warning note to explain its importance.