### PR TITLE
Fix darkmode logo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,6 +18,7 @@ module.exports = {
       logo: {
         alt: 'NodeCG Logo',
         src: 'img/logo.png',
+        srcDark: 'img/logo.png',
       },
       items: [
         {


### PR DESCRIPTION
The logo on the dark mode was missing and wasn't being defaulted to the "light" theme one. Adding srcDark in the config fixes it.