### PR TITLE
Add depth flag to installation git clone command

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -22,7 +22,7 @@ nodecg setup
 Cloning from GitHub:
 
 ```bash
-git clone --branch legacy-1.x https://github.com/nodecg/nodecg.git
+git clone --depth 1 --branch legacy-1.x https://github.com/nodecg/nodecg.git
 cd nodecg
 npm install --production
 ```


### PR DESCRIPTION
For people who just want to copy and paste commands from the docs, this will run faster and take less disk space