### PR TITLE
Fix json structure in the config example

### DIFF
--- a/docs/nodecg-configuration.md
+++ b/docs/nodecg-configuration.md
@@ -113,30 +113,30 @@ module.exports = {
 				},
 			],
 		},
-		logging: {
-			console: {
-				enabled: true,
-				timestamps: false,
-				level: 'verbose',
-				replicants: false,
-			},
-			file: {
-				enabled: true,
-				timestamps: true,
-				path: 'logs/server.log',
-				level: 'info',
-				replicants: false,
-			},
-		},
-		ssl: {
-			enabled: false,
-			keyPath: '',
-			certificatePath: '',
-		},
-		sentry: {
+	},
+	logging: {
+		console: {
 			enabled: true,
-			dsn: 'https://xxx:yyy@sentry.io/zzz',
+			timestamps: false,
+			level: 'verbose',
+			replicants: false,
 		},
+		file: {
+			enabled: true,
+			timestamps: true,
+			path: 'logs/server.log',
+			level: 'info',
+			replicants: false,
+		},
+	},
+	ssl: {
+		enabled: false,
+		keyPath: '',
+		certificatePath: '',
+	},
+	sentry: {
+		enabled: true,
+		dsn: 'https://xxx:yyy@sentry.io/zzz',
 	},
 };
 ```


### PR DESCRIPTION
Previously, the `logging`  was inside the `login`, and it would throw an error `Error: "login.logging" is not allowed` when using the config as is.

This PR fixes this issue.