### PR TITLE
Add extensions and minor adjustments

### DIFF
--- a/docs/classes/findCue.md
+++ b/docs/classes/findCue.md
@@ -10,6 +10,6 @@ Returns the sound cue of the provided `cueName` in the current bundle. Returns u
 
 ### Parameters {#parameters}
 
-|  Name   |  Type  | Description |
-| ------- | ------ | ----------- |
-| cueName | String |             |
+|  Name   |  Type  | Description           |
+| ------- | ------ | --------------------- |
+| cueName | String | Name of the sound cue |

--- a/docs/classes/getDialog.md
+++ b/docs/classes/getDialog.md
@@ -14,7 +14,7 @@ Returns the specified dialog element.
 
 ### Parameters {#parameters}
 
-| Name   | Type   | Attributes    | Default   | Description                                 |
-| ------ | ------ | ------------- | --------- | ------------------------------------------- |
-| name   | string |               |           | The desired dialog's name.                  |
-| bundle | string | &lt;optional> | CURR_BNDL | The bundle from which to select the dialog. |
+| Name   | Type   | Attributes    | Default        | Description                                 |
+| ------ | ------ | ------------- | -------------- | ------------------------------------------- |
+| name   | string |               |                | The desired dialog's name.                  |
+| bundle | string | &lt;optional> | Current bundle | The bundle from which to select the dialog. |

--- a/docs/classes/getDialogDocument.md
+++ b/docs/classes/getDialogDocument.md
@@ -14,7 +14,7 @@ Returns the specified dialog's iframe document.
 
 ### Parameters {#parameters}
 
-| Name   | Type   | Attributes    | Default   | Description                                 |
-| ------ | ------ | ------------- | --------- | ------------------------------------------- |
-| name   | string |               |           | The desired dialog's name.                  |
-| bundle | string | &lt;optional> | CURR_BNDL | The bundle from which to select the dialog. |
+| Name   | Type   | Attributes    | Default        | Description                                 |
+| ------ | ------ | ------------- | -------------- | ------------------------------------------- |
+| name   | string |               |                | The desired dialog's name.                  |
+| bundle | string | &lt;optional> | Current bundle | The bundle from which to select the dialog. |

--- a/docs/classes/getSocketIOServer.md
+++ b/docs/classes/getSocketIOServer.md
@@ -1,7 +1,7 @@
 ---
 id: getSocketIOServer
-title: getSocketIOServer()
-sidebar_label: getSocketIOServer()
+title: getSocketIOServer
+sidebar_label: getSocketIOServer
 ---
 
 :::important Extension Only

--- a/docs/classes/listenFor.md
+++ b/docs/classes/listenFor.md
@@ -14,8 +14,8 @@ You may define multiple listenFor handlers for a given message. They will be cal
 
 ### Parameters {#parameters}
 
-| Name        | Type     | Attributes    | Default   | Description                                                  |
-| ----------- | -------- | ------------- | --------- | ------------------------------------------------------------ |
-| messageName | string   |               |           | The name of the message.                                     |
-| bundleName  | string   | &lt;optional> | CURR_BNDL | The bundle namespace to in which to listen for this message. |
-| handlerFunc | function |               |           | The callback fired when this message is received.            |
+| Name        | Type     | Attributes    | Default        | Description                                                  |
+| ----------- | -------- | ------------- | -------------- | ------------------------------------------------------------ |
+| messageName | string   |               |                | The name of the message.                                     |
+| bundleName  | string   | &lt;optional> | Current bundle | The bundle namespace to in which to listen for this message. |
+| handlerFunc | function |               |                | The callback fired when this message is received.            |

--- a/docs/classes/log.md
+++ b/docs/classes/log.md
@@ -1,10 +1,10 @@
 ---
 id: log
-title: log()
-sidebar_label: log()
+title: log
+sidebar_label: log
 ---
 
-`log()`
+`log`
 
 An instance of NodeCG's Logger, with the following methods. The logging level is set in cfg/nodecg.json, NodeCG's global config file.
 

--- a/docs/classes/mount.md
+++ b/docs/classes/mount.md
@@ -1,7 +1,7 @@
 ---
 id: mount
-title: mount()
-sidebar_label: mount()
+title: mount
+sidebar_label: mount
 ---
 
 :::important Extension Only

--- a/docs/classes/nodecg.md
+++ b/docs/classes/nodecg.md
@@ -29,7 +29,7 @@ Provides information about the current git status of this bundle, if found.
 
 #### Properties {#properties}
 
-|    Name   |  Type  |   Attribues   |                  Description                    |
+|    Name   |  Type  |  Attributes   |                  Description                    |
 | --------- | ------ | ------------- | ----------------------------------------------- |
 | branch    | String |               | What branch this bundle is on.                  |
 | hash      | String |               | The full hash of the commit this bundle is on.  |
@@ -53,8 +53,7 @@ This can only be used in code which runs on the server.
 
 Object containing references to all other loaded extensions. To access another bundle's extension, it must be declared as a bundleDependency in your bundle's manifest.
 
-```js
-// bundles/my-bundle/package.json
+```js title="bundles/my-bundle/package.json"
 {
     "name": "my-bundle"
     ...
@@ -62,15 +61,18 @@ Object containing references to all other loaded extensions. To access another b
         "other-bundle": "^1.0.0"
     }
 }
+```
 
-// bundles/my-bundle/extension.js
+```js title="bundles/my-bundle/extension.js"
 module.exports = function(nodecg) {
     const otherBundle = nodecg.extensions['other-bundle'];
     // Now I can use `otherBundle`!
 }
 ```
 
-### Logger _:Object_ {#logger}
+### Logger {#logger}
+
+_Object_
 
 Provides easy access to the Logger class. Useful in cases where you want to create your own custom logger.
 

--- a/docs/classes/nodecg.md
+++ b/docs/classes/nodecg.md
@@ -72,7 +72,7 @@ module.exports = function(nodecg) {
 
 ### Logger {#logger}
 
-_Object_
+Type: _Object_
 
 Provides easy access to the Logger class. Useful in cases where you want to create your own custom logger.
 

--- a/docs/classes/playSound.md
+++ b/docs/classes/playSound.md
@@ -14,10 +14,10 @@ Plays the sound cue of the provided `cueName` in the current bundle. Does nothin
 
 ### Parameters {#parameters}
 
-| Name    | Type   | Attributes    | Description |
-| ------- | ------ | ------------- | ----------- |
-| cueName | String |               |             |
-| opts    | Object | &lt;optional> |             |
+| Name    | Type   | Attributes    | Description                        |
+| ------- | ------ | ------------- | ---------------------------------- |
+| cueName | String |               | Sound cue's name                   |
+| opts    | Object | &lt;optional> | [Options](#opts) for the sound cue |
 
 #### Opts {#opts}
 

--- a/docs/classes/readReplicant.md
+++ b/docs/classes/readReplicant.md
@@ -10,11 +10,11 @@ Reads the value of a replicant once, and doesn't create a subscription to it. Al
 
 ### Parameters {#parameters}
 
-| Name   | Type     | Attributes    | Default   | Description                                                                              |
-| ------ | -------- | ------------- | --------- | ---------------------------------------------------------------------------------------- |
-| name   | string   |               |           | The name of the replicant.                                                               |
-| bundle | string   | &lt;optional> | CURR_BNDL | The bundle namespace to in which to look for this replicant.                             |
-| cb     | function |               |           | _Browser only_ The callback that handles the server's response which contains the value. |
+| Name   | Type     | Attributes    | Default        | Description                                                                              |
+| ------ | -------- | ------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| name   | string   |               |                | The name of the replicant.                                                               |
+| bundle | string   | &lt;optional> | Current bundle | The bundle namespace to in which to look for this replicant.                             |
+| cb     | function |               |                | _Browser only_ The callback that handles the server's response which contains the value. |
 
 ### Example {#example}
 

--- a/docs/classes/sendMessage.md
+++ b/docs/classes/sendMessage.md
@@ -44,8 +44,7 @@ nodecg.sendMessage('printMessage', 'dope.');
 
 Sending a message and replying with an acknowledgement:
 
-```js
-// bundles/my-bundle/extension.js
+```js title="bundles/my-bundle/extension.js"
 module.exports = function(nodecg) {
     nodecg.listenFor('multiplyByTwo', (value, ack) => {
         if (value === 4) {
@@ -53,7 +52,7 @@ module.exports = function(nodecg) {
             return;
         }
 
-        // acknowledgements should always be error-first callbacks.
+        // Acknowledgements should always be error-first callbacks.
         // If you do not wish to send an error, use a falsey value
         // like "null" instead.
         if (ack && !ack.handled) {
@@ -61,9 +60,10 @@ module.exports = function(nodecg) {
         }
     });
 }
+```
 
-// bundles/my-bundle/graphics/script.js
-// Both of these examples are functionally identical.
+```js  title="bundles/my-bundle/graphics/script.js"
+/* Both of these examples are functionally identical. */
 
 // Promise acknowledgement
 nodecg.sendMessage('multiplyByTwo', 2)

--- a/docs/classes/stopAllSounds.md
+++ b/docs/classes/stopAllSounds.md
@@ -1,7 +1,7 @@
 ---
 id: stopAllSounds
-title: stopAllSounds()
-sidebar_label: stopAllSounds()
+title: stopAllSounds
+sidebar_label: stopAllSounds
 ---
 
 :::important Browser Only

--- a/docs/classes/stopSound.md
+++ b/docs/classes/stopSound.md
@@ -14,6 +14,6 @@ Stops all currently playing instances of the provided `cueName`.
 
 ### Parameters {#parameters}
 
-| Name    | Type   | Description |
-| ------- | ------ | ----------- |
-| cueName | String |             |
+| Name    | Type   | Description      |
+| ------- | ------ | ---------------- |
+| cueName | String | Sound cue's name |

--- a/docs/classes/unlisten.md
+++ b/docs/classes/unlisten.md
@@ -12,11 +12,11 @@ Messages are namespaced by bundle. To remove a listener to a message in another 
 
 ### Parameters {#parameters}
 
-| Name        | Type     | Attributes    | Default   | Description                                                                                          |
-| ----------- | -------- | ------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| messageName | string   |               |           | The name of the message.                                                                             |
-| bundleName  | string   | &lt;optional> | CURR_BNDL | The bundle namespace to in which to listen for this message                                          |
-| handlerFunc | function |               |           | A reference to a handler function added as a listener to this message via [listenFor](listenFor.md). |
+| Name        | Type     | Attributes    | Default        | Description                                                                                          |
+| ----------- | -------- | ------------- | -------------- | ---------------------------------------------------------------------------------------------------- |
+| messageName | string   |               |                | The name of the message.                                                                             |
+| bundleName  | string   | &lt;optional> | Current bundle | The bundle namespace to in which to listen for this message                                          |
+| handlerFunc | function |               |                | A reference to a handler function added as a listener to this message via [listenFor](listenFor.md). |
 
 ### Example {#example}
 

--- a/docs/classes/waitForReplicants.md
+++ b/docs/classes/waitForReplicants.md
@@ -14,9 +14,9 @@ This method is only useful in client-side code. Server-side code never has to wa
 
 ### Parameters {#parameters}
 
-|    Name    |    Type   | Description |
-| ---------- | --------- | ----------- |
-| replicants | Replicant |             |
+|    Name    |    Type   | Description                   |
+| ---------- | --------- | ----------------------------- |
+| replicants | Replicant | Replicant objects to wait for |
 
 ### Example {#example}
 

--- a/docs/custom-routes.md
+++ b/docs/custom-routes.md
@@ -6,9 +6,7 @@ sidebar_label: Custom Routes
 
 NodeCG uses [express](http://expressjs.com/) for its routing, and exposes a helper for creating routes easily:
 
-```js
-// bundles/my-bundle/extension.js
-
+```js title="bundles/my-bundle/extension.js"
 module.exports = function(nodecg) {
     const router = nodecg.Router();
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,117 @@
+---
+description: Extension documentation
+id: extensions
+title: Extensions
+sidebar_label: Extensions
+---
+
+Extensions are server-side code that runs on the NodeCG server. They are vital for any NodeCG bundle.
+
+**Extensions are the first things that run in a bundle** so it is the best place to setup replicants and other data that will be used throughout a bundle.
+
+## What to use extensions for
+
+- Setting up replicants
+- Handling changes to replicants to keep dashboards as a "dumb terminal"
+- Getting data from other websites/services
+- Automating your bundle
+
+## Extension entrypoint
+
+NodeCG looks for 2 file locations.
+
+- A single file called `extension.js` in the bundle's root directory.
+- A folder called `extension` with an `index.js` in the bundle's root directory.
+
+If both exist NodeCG will throw an error and not run any extensions from that bundle.
+
+:::tip
+We recommend the folder method unless your bundle is very basic and doesn't need much functionality.
+:::
+
+## Single file
+
+```javascript title="extension.js"
+module.exports = function (nodecg) {
+    nodecg.Replicant('test-replicant');
+}
+```
+
+## Using multiple files
+
+To make programming easier we split different functionality into different files. The problem is that NodeCG is only injected into the first file it touches. There are a few methods to deal with this:
+
+### Utility script
+
+```typescript title="nodecg-api-context.ts"
+import type NodeCG from '@nodecg/types';
+
+let context: NodeCG.ServerAPI;
+
+export function get(): NodeCG.ServerAPI {
+    return context;
+}
+
+export function set(ctx: NodeCG.ServerAPI) {
+    context = ctx;
+}
+```
+
+```typescript title="index.ts"
+import type NodeCG from '@nodecg/types';
+import * as nodecgApiContext from './nodecg-api-context';
+
+let ncgConfig: NodeCG.ServerAPI<ConfigSchema>['bundleConfig'];
+
+module.exports = (nodecg: NodeCG.ServerAPI) => {
+    // Store a reference to this nodecg API context in a place where other libs can easily access it.
+    // This must be done before any other files are `require`d.
+    nodecgApiContext.set(nodecg);
+    ncgConfig = nodecg.bundleConfig;
+    init().then(() => {
+        nodecg.log.info('Initialization successful.');
+    }).catch(error => {
+        nodecg.log.error('Failed to initialize:', error);
+    });
+};
+
+async function init() {
+    require('./example.ts');
+}
+```
+
+```typescript title="example.ts"
+import * as nodecgApiContext from './nodecg-api-context';
+
+const nodecg = nodecgApiContext.get();
+
+// Initializes a replicant
+nodecg.Replicant<string>('test-replicant');
+```
+
+### Have each extension export a function to call
+
+```typescript title="example.ts"
+import type NodeCG from '@nodecg/types';
+
+export const test = (nodecg: NodeCG) => {
+    nodecg.Replicant<string>('test-replicant');
+}
+```
+
+```typescript title="index.ts"
+import type NodeCG from '@nodecg/types';
+
+import { test } from "./example";
+
+export default (nodecg: NodeCG) => {
+    test(nodecg);
+};
+```
+
+## Extension specific API
+
+- [getSocketIOServer](./classes/getSocketIOServer.md)
+- [mount](./classes/mount.md)
+- [Router](./classes/router.md)
+- [Events](./classes/nodecg.md#events-events)

--- a/docs/nodecg-configuration.md
+++ b/docs/nodecg-configuration.md
@@ -71,8 +71,7 @@ NodeCG is configured via a `cfg/nodecg.js`, `cfg/nodecg.yaml`, or `cfg/nodecg.js
 
 ### Example {#example} Config {#example}
 
-```js
-// cfg/nodecg.js
+```js title="cfg/nodecg.js"
 module.exports = {
     host: '0.0.0.0',
     port: 9090,

--- a/docs/what-is-nodecg.md
+++ b/docs/what-is-nodecg.md
@@ -33,21 +33,19 @@ The NodeCG project exists to accomplish the following goals:
 - Remain as close to the web platform as possible.
 - Support broadcasts of any size and ambition.
 
-Let's unpack what these statements mean:
-
-### > Make broadcast graphics (also known as "character generation" or "CG") more accessible {#goal-accessible}
+### Make broadcast graphics more accessible {#goal-accessible}
 
 Historically, broadcast graphics have been expensive. They either required expensive hardware, expensive software, or both. NodeCG was originally created to provide real-time broadcast graphics for Tip of the Hats, which is an all-volunteer charity fundraiser that had a budget of $0 for its first several years.
 
 Now, it is possible to create an ambitious broadcast using entirely free software and consumer hardware. The NodeCG project embraces this democratization of broadcast technology.
 
-### > Remain as close to the web platform as possible {#goal-web}
+### Remain as close to the web platform as possible {#goal-web}
 
 NodeCG graphics are just webpages. There is absolutely nothing special or unique about them. This is their greatest strength.
 
 By building on the web platform, and not building too many abstractions on top of it, people developing broadcast graphics with NodeCG have access to the raw potential of the web. New APIs and capabilities are continually being added to the web platform, and NodeCG developers should have access to the entirety of what the web can offer.
 
-### > Support broadcasts of any size and ambition {#goal-size}
+### Support broadcasts of any size and ambition {#goal-size}
 
 NodeCG's roots are in small broadcasts with no budget. More recently, NodeCG has begun seeing use in increasingly elaborate productions. We believe that one set of tools can and should be able to scale up from the smallest show all the way to the biggest fathomable show. Whether you're using OBS for everything, or a hardware switcher with a traditional key/fill workflow, NodeCG can be a part of any broadcast graphics system.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodecg-docs",
+  "name": "docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,14 +8,14 @@
         "@docusaurus/core": "^2.4.1",
         "@docusaurus/preset-classic": "^2.4.1",
         "classnames": "2.3.2",
-        "docusaurus-lunr-search": "^2.3.2",
+        "docusaurus-lunr-search": "^2.4.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^2.4.1",
-        "@tsconfig/docusaurus": "^1.0.7",
-        "typescript": "^5.1.3"
+        "@tsconfig/docusaurus": "^2.0.0",
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -3266,9 +3266,9 @@
       }
     },
     "node_modules/@tsconfig/docusaurus": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@tsconfig/docusaurus/-/docusaurus-1.0.7.tgz",
-      "integrity": "sha512-ffTXxGIP/IRMCjuzHd6M4/HdIrw1bMfC7Bv8hMkTadnePkpe0lG0oDSdbRpSDZb2rQMAgpbWiR10BvxvNYwYrg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/docusaurus/-/docusaurus-2.0.0.tgz",
+      "integrity": "sha512-X5wptT7pXA/46/IRFTW76oR5GNjoy9qjNM/1JGhFV4QAsmLh3YUpJJA+Vpx7Ds6eEBxSxz1QrgoNEBy6rLVs8w==",
       "dev": true
     },
     "node_modules/@types/body-parser": {
@@ -5617,12 +5617,12 @@
       }
     },
     "node_modules/docusaurus-lunr-search": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/docusaurus-lunr-search/-/docusaurus-lunr-search-2.3.2.tgz",
-      "integrity": "sha512-Ngvm2kXwliWThqAThXI1912rOKHlFL7BjIc+OVNUfzkjpk5ar4TFEh+EUaaMOLw4V0BBko3CW0Ym7prqqm3jLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-lunr-search/-/docusaurus-lunr-search-2.4.1.tgz",
+      "integrity": "sha512-UOgaAypgO0iLyA1Hk4EThG/ofLm9/JldznzN98ZKr7TMYVjMZbAEaIBKLAUDFdfOPr9D5EswXdLn39/aRkwHMA==",
       "dependencies": {
         "autocomplete.js": "^0.37.0",
-        "classnames": "^2.2.6",
+        "clsx": "^1.2.1",
         "gauge": "^3.0.0",
         "hast-util-select": "^4.0.0",
         "hast-util-to-text": "^2.0.0",
@@ -11730,9 +11730,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "@docusaurus/preset-classic": "^2.4.1",
     "classnames": "2.3.2",
     "docusaurus-lunr-search": "^2.4.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "@docusaurus/core": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.1",
     "classnames": "2.3.2",
-    "docusaurus-lunr-search": "^2.3.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "docusaurus-lunr-search": "^2.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.1",
-    "@tsconfig/docusaurus": "^1.0.7",
-    "typescript": "^5.1.3"
+    "@tsconfig/docusaurus": "^2.0.0",
+    "typescript": "^5.1.6"
   }
 }

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,13 +6,14 @@ module.exports = {
 			'manifest',
 			'nodecg-configuration',
 			'using-npm',
+			'extensions',
 			'bundle-configuration',
 			'assets',
 			'sounds',
 			'replicant-schemas',
 			'making-dialogs',
 			'portable-nodecg',
-			'working-on-nodecg-core'
+			'working-on-nodecg-core',
 		],
 		Advanced: [
 			'mounts', 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -30,6 +30,10 @@
 	--ifm-color-info: #000000;
 	--ifm-color-danger: #b4040a;
 	--ifm-color-success: #006600;
+
+	--ifm-table-border-color: var(--nodecg-light-primary);
+	--ifm-table-stripe-background: var(--ifm-table-background);
+	--ifm-breadcrumb-color-active: var(--ifm-navbar-background-color);
 }
 
 .docusaurus-highlight-code-line {
@@ -51,8 +55,8 @@ html[data-theme="dark"] {
 	--ifm-link-color: var(--nodecg-light-secondary);
 	--ra-color-important: #ffffff;
 	--ifm-blockquote-color: #b7b7b7;
-
 	--ifm-color-info: #ffffff;
+	--ifm-table-border-color: #dadde1;
 }
 
 /* Info admonition colour */
@@ -95,12 +99,57 @@ html[data-theme="dark"] a code {
 	color: var(--nodecg-light-secondary);
 }
 
-/* Information alert */
-html[data-theme="dark"] .alert.alert--info {
-	/* color: #000000; */
-}
-
 /* Information admonition icon black */
 html[data-theme="dark"] .admonition-important svg {
 	fill: #000000;
+}
+
+/* Fix mobile light mode style */
+@media screen and (max-width: 996px) {
+	.menu__link {
+		color: var(--ifm-navbar-link-color);
+		--ifm-menu-color-background-active: #ffffff0d;
+	}
+
+	.menu__link--active {
+		color: var(--ifm-navbar-link-hover-color);
+	}
+
+	.navbar-sidebar__back {
+		--ifm-menu-color-background-active: #ffffff0d;
+	}
+}
+
+/* Table styling */
+table,
+tr,
+td,
+th {
+	border-collapse: collapse;
+}
+
+table {
+	display: table;
+	border-radius: 8px;
+
+	border-style: hidden;
+	/* hide standard table (collapsed) border */
+	box-shadow: inset 0 0 0 1px var(--ifm-table-border-color);
+}
+
+table thead tr {
+	border-width: 1px;
+}
+
+th {
+	text-align: start;
+}
+
+th,
+td {
+	line-height: 1.6;
+}
+
+thead th:empty {
+	display: none;
 }


### PR DESCRIPTION
Added a dedicated extensions page and made some more minor tweaks/QoL improvements.

Added:
- Added Extensions document
	- Which type of export to use in the index.ts code examples. I don't mind both but it can be confusing for new people.
- New table styling

Adjusted:
- Update dependencies to latest
- Remove "using npm" from sidebar
	- It's just a guide on how to install a package using npm and I don't think that's relevant for NodeCG docs
- Convert commented file names/paths to code block titles. Affected files:
	- custom-routes.md
	- nodecg-configuration.md
	- nodecg.md
	- sendMessage.md
- Remove arrows from NodeCG goals
- Added descriptions when they were missing. Affected files:
	- findCue.md
	- playSound.md
	- stopSound.md
	- waitForReplicants.md
- Rename CURR_BUNDL to be "Current Bundle". Affected files:
	- getDialog.md
	- getDialogDocument.md
	- listenFor.md
	- readReplicant.md
	- unlisten.md
- Remove parenthesis from titles to be consistent. Affected files:
	- getSocketIOServer.md
	- log.md
	- mount.md
	- stopAllSounds.md

Fixed:
- Light mode mobile sidebar text colour
- Light mode breadcrumb text colour

Closes #3